### PR TITLE
Avoid ObjectDisposedException when running on .NET 9.0 or 10.0

### DIFF
--- a/Ramone.Tests.Common/Codecs/CatAsHtmlCodec.cs
+++ b/Ramone.Tests.Common/Codecs/CatAsHtmlCodec.cs
@@ -27,7 +27,7 @@ namespace Ramone.Tests.Common.Codecs
     public void WriteTo(WriterContext context)
     {
       Cat c = (Cat)context.Data;
-      using (StreamWriter w = new StreamWriter(context.HttpStream, Encoding.UTF8))
+      using (StreamWriter w = new StreamWriter(context.HttpStream, Encoding.UTF8, 1024, leaveOpen: true))
       {
         // Absolute meaningless post data
         w.Write(string.Format("<html><body><p>{0}</p></body></html>", c.Name));

--- a/Ramone.Tests.Common/Codecs/CatAsTextCodec.cs
+++ b/Ramone.Tests.Common/Codecs/CatAsTextCodec.cs
@@ -28,7 +28,7 @@ namespace Ramone.Tests.Common.Codecs
     public void WriteTo(WriterContext context)
     {
       Cat c = (Cat)context.Data;
-      using (StreamWriter w = new StreamWriter(context.HttpStream, Encoding.UTF8))
+      using (StreamWriter w = new StreamWriter(context.HttpStream, Encoding.UTF8, 1024, leaveOpen: true))
       {
         w.Write(c.Name);
       }

--- a/Ramone.Tests/Ramone.Tests.csproj
+++ b/Ramone.Tests/Ramone.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net6;net8</TargetFrameworks>
+    <TargetFrameworks>net48;net6;net8;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">

--- a/Ramone/MediaTypes/TextCodecBase.cs
+++ b/Ramone/MediaTypes/TextCodecBase.cs
@@ -33,7 +33,7 @@ namespace Ramone.MediaTypes
     {
       Encoding enc = MediaTypeParser.GetEncodingFromCharset(context.Request.ContentType, DefaultEncoding ?? context.Session.DefaultEncoding);
 
-      using (var writer = new StreamWriter(context.HttpStream, enc))
+      using (var writer = new StreamWriter(context.HttpStream, enc, 1024, leaveOpen: true))
       {
         WriteTo(context.Data as TEntity, writer, context);
       }

--- a/Ramone/MediaTypes/XmlStreamCodecBase.cs
+++ b/Ramone/MediaTypes/XmlStreamCodecBase.cs
@@ -42,8 +42,9 @@ namespace Ramone.MediaTypes
     public void WriteTo(WriterContext context)
     {
       Encoding enc = MediaTypeParser.GetEncodingFromCharset(context.Request.ContentType, context.Session.DefaultEncoding);
+      var writerSettings = new XmlWriterSettings { Encoding = enc, CloseOutput = false };
 
-      using (var writer = new XmlTextWriter(context.HttpStream, enc))
+      using (var writer = XmlWriter.Create(context.HttpStream, writerSettings))
       {
         WriteTo(context.Data, writer, context);
       }

--- a/Ramone/Ramone.csproj
+++ b/Ramone/Ramone.csproj
@@ -15,9 +15,9 @@
     <RepositoryUrl>https://github.com/JornWildt/Ramone.git</RepositoryUrl>
     <RepositoryType>GIT</RepositoryType>
     <PackageTags>REST JSON XML HTTP WEB API</PackageTags>
-    <Version>5.0.0.0</Version>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.0.0.0</FileVersion>
+    <Version>5.0.1</Version>
+    <AssemblyVersion>5.0.1.0</AssemblyVersion>
+    <FileVersion>5.0.1.0</FileVersion>
     <Authors>Jørn Wildt and others</Authors>
     <Company>Jørn Wildt</Company>
     <Description>Ramone is a C# library that simplifies access to HTTP based Web APIs and REST services. It has a strong focus on REST and hypermedia and implements elements of the Uniform Interface as first class citizens of the API.
@@ -26,6 +26,9 @@ Ramone has built-in support for serialization of simple objects as JSON, XML, UR
     <Copyright>Copyright ©2010, Ramone team</Copyright>
     <Product />
     <PackageReleaseNotes>
+      5.0.1 -
+              Avoid ObjectDisposedException when running on .NET 9+
+              Use latest Newtonsoft.Json - 13.0.4
       5.0.0 - 
               Removed support for .NET Core 3.1.
               Use System.Net.Http.Headers.AuthenticationHeaderValue to parse authentication header.</PackageReleaseNotes>

--- a/Ramone/Ramone.csproj
+++ b/Ramone/Ramone.csproj
@@ -32,7 +32,7 @@ Ramone has built-in support for serialization of simple objects as JSON, XML, UR
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Tavis.UriTemplates" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
When running on .NET 10 (or 9) a Post triggers an ObjectDisposedException:

System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.RequestBufferingStream'.
   at Ramone.BaseRequest.WriteBody(Stream requestStream, HttpWebRequest request, Boolean includeBody)
   at Ramone.BaseRequest.DoRequest(Uri url, String method, Boolean includeBody, Action`1 requestModifier, Int32 retryLevel)
   at Ramone.BaseRequest.DoRequest[TResponse](String method, Int32 retryLevel)
   at Ramone.Request.Post[TResponse](Object body)

BaseRequest.WriteBody calls requestStream.Flush() and requestStream.Close(). But the requestStream is already closed at that point. Both BaseRequest.WriteBody and TextCodecBase.WriteTo(WriterContext context) wants to close the stream - only one of them should do it.
